### PR TITLE
Hiding the keyboard a bit better

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -91,11 +91,11 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
                 }
             }
 
-            override fun onTransitionTrigger(p0: MotionLayout?, p1: Int, p2: Boolean, p3: Float) {
+            override fun onTransitionTrigger(motionLayout: MotionLayout?, triggerId: Int, positive: Boolean, progress: Float) {
                 // do nothing
             }
 
-            override fun onTransitionStarted(p0: MotionLayout?, p1: Int, p2: Int) {
+            override fun onTransitionStarted(motionLayout: MotionLayout?, startId: Int, endId: Int) {
                 // do nothing
             }
 

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -1,5 +1,6 @@
 package com.sduduzog.slimlauncher.ui.main
 
+import android.app.Activity
 import android.content.*
 import android.content.pm.LauncherApps
 import android.os.Bundle
@@ -13,6 +14,9 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
+import androidx.constraintlayout.motion.widget.MotionLayout
+import androidx.constraintlayout.motion.widget.MotionLayout.TransitionListener
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation
 import com.sduduzog.slimlauncher.BuildConfig
@@ -75,6 +79,28 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
         viewModel.addAppViewModel.apps.observe(viewLifecycleOwner, Observer {
             it?.let { apps ->
                 openAppAdapter.setItems(apps)
+            }
+        })
+        home_fragment.setTransitionListener(object : TransitionListener {
+            override fun onTransitionCompleted(motionLayout: MotionLayout?, currentId: Int) {
+                // hide the keyboard and remove focus from the EditText when swiping back up
+                if (currentId == motionLayout?.startState) {
+                    app_drawer_edit_text.clearFocus()
+                    val inputMethodManager = requireContext().getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+                    inputMethodManager.hideSoftInputFromWindow(requireView().windowToken, 0)
+                }
+            }
+
+            override fun onTransitionTrigger(p0: MotionLayout?, p1: Int, p2: Boolean, p3: Float) {
+                // do nothing
+            }
+
+            override fun onTransitionStarted(p0: MotionLayout?, p1: Int, p2: Int) {
+                // do nothing
+            }
+
+            override fun onTransitionChange(motionLayout: MotionLayout?, startId: Int, endId: Int, progress: Float) {
+                // do nothing
             }
         })
     }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -99,6 +99,7 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
     override fun onStop() {
         super.onStop()
         activity?.unregisterReceiver(receiver)
+        resetAppDrawerEditText()
     }
 
     private fun setEventListeners() {
@@ -188,7 +189,6 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
 
     override fun onAppClicked(app: App) {
         launchApp(app.packageName, app.activityName, app.userSerial)
-        app_drawer_edit_text.clearFocus() // dismiss the on-screen keyboard
         home_fragment.transitionToStart()
     }
 
@@ -204,6 +204,11 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
         } catch (e: Exception) {
             // Do no shit yet
         }
+    }
+
+    private fun resetAppDrawerEditText() {
+        app_drawer_edit_text.setText("")
+        app_drawer_edit_text.clearFocus()
     }
 
     private val onTextChangeListener: TextWatcher = object : TextWatcher {

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/AddAppFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/AddAppFragment.kt
@@ -1,5 +1,6 @@
 package com.sduduzog.slimlauncher.ui.options
 
+import android.app.Activity
 import android.content.Context
 import android.content.pm.LauncherApps
 import android.os.Bundle
@@ -10,6 +11,7 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation
@@ -60,6 +62,9 @@ class AddAppFragment : BaseFragment(), OnAppClickedListener {
     override fun onPause() {
         super.onPause()
         add_app_fragment_edit_text?.removeTextChangedListener(onTextChangeListener)
+
+        val inputMethodManager = requireContext().getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(requireView().windowToken, 0)
     }
 
     private val onTextChangeListener: TextWatcher = object : TextWatcher {


### PR DESCRIPTION
I was working on the same issue for Unlauncher when you posted your PR, so I thought I'd contribute my improvements to your fix.

I moved the `clearFocus` call to `onStop` instead of `onAppClicked` because this covers more cases where we would want to clear the focus, as in general I think we always want to reset the text-box when the user opens a different application. I also fixed the issue where the keyboard would stay up after closing the app drawer.

EDIT: Added a fix to hide the keyboard after adding an app to the home screen.